### PR TITLE
Allow neighborhood filtering on post type pages for zonein

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -486,7 +486,7 @@ function citylimits_print_event_time() {
 		if ( $date ) {
 			echo '<span class="date">' . date( 'F d, Y', $date ) . '</span> ';
 			echo '<span class="time">' . date( 'g:ia', $date ) . '</span> ';
-		}	
+		}
 	}
 }
 add_action( 'largo_after_post_header', 'citylimits_print_event_time' );
@@ -501,3 +501,24 @@ function citylimits_modify_zonein_events_query( $query ) {
 	return $query;
 }
 add_action( 'pre_get_posts', 'citylimits_modify_zonein_events_query' );
+
+// Creates the ability to filter
+function zonein_tax_archive_query( $query ) {
+	if ( $query->is_archive() && isset( $query->query['post-type'] ) && isset( $_GET['neighborhood'] ) && ! empty( $_GET['neighborhood'] ) ) {
+		$query->set( 'tax_query', array(
+			'relation' => 'AND',
+			array(
+				'taxonomy' => 'post-type',
+				'field'    => 'slug',
+				'terms'    => array( $query->query['post-type'] ),
+			),
+			array(
+				'taxonomy' => 'neighborhoods',
+				'field' => 'slug',
+				'terms' => $_GET['neighborhood'],
+			),
+		) );
+		return $query;
+	}
+}
+add_action( 'pre_get_posts', 'zonein_tax_archive_query', 1 );

--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -515,7 +515,7 @@ function zonein_tax_archive_query( $query ) {
 			array(
 				'taxonomy' => 'neighborhoods',
 				'field' => 'slug',
-				'terms' => $_GET['neighborhood'],
+				'terms' => sanitize_key( $_GET['neighborhood'] ),
 			),
 		) );
 		return $query;

--- a/wp-content/themes/citylimits/taxonomy-neighborhoods.php
+++ b/wp-content/themes/citylimits/taxonomy-neighborhoods.php
@@ -141,7 +141,7 @@ $queried_object = get_queried_object();
 								</div>
 							</div>
 						<?php endwhile; ?>
-						<div class="morelink"><a href="<?php echo get_term_link( 'news', 'post-type' ); ?>" class="btn more">More News</a></div>
+						<div class="morelink"><a href="<?php echo get_term_link( 'news', 'post-type' ); ?>?neighborhood=<?php echo $queried_object->slug; ?>" class="btn more">More News</a></div>
 					</section>
 				<?php endif; ?>
 


### PR DESCRIPTION
This PR augments the URL for "more news" shown on Neighborhood pages like http://citylimitsorg.staging.wpengine.com/neighborhoods/gowanus/

New url structure is http://citylimitsorg.staging.wpengine.com/post-type/news/?neighborhood=gowanus

Code was also added to filter the taxonomy page above to display only content related to the neighborhood specified.

Per https://app.asana.com/0/180359020271712/221650413798655/f