### PR TITLE
Remove featured media from single post templates

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -27,6 +27,7 @@ function largo_child_require_files() {
 		'/inc/registration.php',
 		'/inc/term-meta.php',
 		'/inc/metaboxes.php',
+		'/inc/post-templates.php',
 		'/inc/enqueue.php',
 		'/inc/widgets/neighborhood-content.php',
 		'/inc/widgets/zonein-events.php',

--- a/wp-content/themes/citylimits/inc/post-templates.php
+++ b/wp-content/themes/citylimits/inc/post-templates.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Remove the largo_remove_hero filter
+ *
+ * Why? Because citylimits has a history of setting featured media *and*
+ * putting that same image directly into the front of the story, and when
+ * Largo decided to unify featured image treatment with https://github.com/INN/Largo/pull/1140,
+ * both images started showing up on City Limits' posts because they still
+ * used the old two-column template.
+ *
+ * So we copied partials/content-single-classic.php and partials/content-single.php
+ * from Largo 0.5.5.2 into this child theme, and commented out the call to largo_hero.
+ *
+ * At that point, Largo is still operating under the assumption that the featured
+ * media will be displayed, so let's disabuse it of that notion by removing this filter.
+ *
+ * @since February 2017
+ * @since Largo 0.5.5.2
+ */
+function citylimits_remove_largo_remove_hero() {
+	remove_filter( 'the_content', 'largo_remove_hero', 1 );
+}
+add_action( 'init',  'citylimits_remove_largo_remove_hero' );

--- a/wp-content/themes/citylimits/partials/content-single-classic.php
+++ b/wp-content/themes/citylimits/partials/content-single-classic.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The template for displaying content in the single.php template
+ *
+ * Copied from Largo in order to comment out the hero image
+ *
+ * @since Largo 0.5.5.2
+ * @since February 21, 2017
+ */
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'hnews item' ); ?> itemscope itemtype="http://schema.org/Article">
+
+	<?php do_action( 'largo_before_post_header' ); ?>
+
+	<header>
+
+		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) )
+			echo '<h2 class="subtitle">' . $subtitle . '</h2>';
+		?>
+		<h5 class="byline"><?php largo_byline(); ?></h5>
+
+		<?php
+			if ( !of_get_option( 'single_social_icons' ) == false ) {
+				largo_post_social_links();
+			}
+		?>
+
+		<?php largo_post_metadata( $post->ID ); ?>
+
+	</header><!-- / entry header -->
+
+	<?php
+		do_action( 'largo_after_post_header' );
+
+		// largo_hero( null,'' );
+
+		do_action( 'largo_after_hero' );
+	?>
+
+	<div class="entry-content clearfix" itemprop="articleBody">
+		<?php largo_entry_content( $post ); ?>
+	</div><!-- .entry-content -->
+
+	<?php do_action( 'largo_after_post_content' ); ?>
+
+	<footer class="post-meta bottom-meta">
+
+	</footer><!-- /.post-meta -->
+
+	<?php do_action( 'largo_after_post_footer' ); ?>
+
+</article><!-- #post-<?php the_ID(); ?> -->

--- a/wp-content/themes/citylimits/partials/content-single.php
+++ b/wp-content/themes/citylimits/partials/content-single.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * The template for displaying content in the single.php template
+ *
+ * Copied from Largo in order to comment out the hero image
+ *
+ * @since Largo 0.5.5.2
+ * @since February 21, 2017
+ */
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'hnews item' ); ?> itemscope itemtype="http://schema.org/Article">
+
+	<?php do_action('largo_before_post_header'); ?>
+
+	<header>
+
+		<?php largo_maybe_top_term(); ?>
+
+		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
+			<h2 class="subtitle"><?php echo $subtitle ?></h2>
+		<?php endif; ?>
+		<h5 class="byline"><?php largo_byline(); ?></h5>
+
+		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
+			largo_post_social_links();
+		} ?>
+
+<?php largo_post_metadata( $post->ID ); ?>
+
+	</header><!-- / entry header -->
+
+	<?php
+		do_action('largo_after_post_header');
+
+		//largo_hero(null,'span12');
+
+		do_action('largo_after_hero');
+	?>
+
+	<?php get_sidebar(); ?>
+
+	<section class="entry-content clearfix" itemprop="articleBody">
+		
+		<?php largo_entry_content( $post ); ?>
+		
+	</section>
+
+	<?php do_action('largo_after_post_content'); ?>
+
+</article>


### PR DESCRIPTION
## changes

- removes `largo_hero` from single post templates
- removes `largo_remove_hero` from `the_content` filter
- explains why in a comment

