### PR TITLE
Increase sticky header logo size

### DIFF
--- a/wp-content/themes/citylimits/less/style.less
+++ b/wp-content/themes/citylimits/less/style.less
@@ -1325,9 +1325,7 @@ body.neighborhoods-lp {
       }
     }
   }
-
+}
 .navbar li.home-icon > a img {
 	height: 45px;
-}
-
 }

--- a/wp-content/themes/citylimits/less/style.less
+++ b/wp-content/themes/citylimits/less/style.less
@@ -437,7 +437,7 @@ body .wpjb .wpjb-login-message ol li {
 }
 
 /**
- * Rezone / ZoneIn Project 
+ * Rezone / ZoneIn Project
  */
 //body.page-template-page-neighborhoods,
 body.neighborhoods-lp {
@@ -569,7 +569,7 @@ body.neighborhoods-lp {
     margin-bottom: .5em;
     letter-spacing: 0;
   }
-  
+
   .read-more {
     font-size:.85em;
     font-weight:bold;
@@ -680,7 +680,7 @@ body.neighborhoods-lp {
         }
       }
     }
-    
+
     h3 a {
       color: @red;
     }
@@ -694,7 +694,7 @@ body.neighborhoods-lp {
       margin-left: 1.7em;
       color:@black;
     }
-  } 
+  }
 
   .bottom-ctas {
     .flex;
@@ -911,13 +911,13 @@ body.neighborhoods-lp {
     .field_sublabel_below .ginput_complex.ginput_container label {
       .a11y;
     }
-    
-    .top_label li.gfield.gf_left_half, 
+
+    .top_label li.gfield.gf_left_half,
     .top_label li.gfield.gf_right_half {
       display:block;
     }
 
-    form li, 
+    form li,
     li {
       margin: 0!important;
     }
@@ -965,7 +965,7 @@ body.neighborhoods-lp {
     }
   }
 
-  @media (max-width: 900px) { 
+  @media (max-width: 900px) {
     ul#menu-zone-in {
 
       >.menu-item {
@@ -995,14 +995,14 @@ body.neighborhoods-lp {
       }
     }
 
-    &.page-template-page-neighborhood-info { 
+    &.page-template-page-neighborhood-info {
       .span8 {
         min-width:100%;
       }
     }
   }
 
-  @media (max-width: 650px) { 
+  @media (max-width: 650px) {
     .rezone-header {
       margin-top:0;
 
@@ -1049,7 +1049,7 @@ body.neighborhoods-lp {
             border-top:none;
           }
         }
-        
+
         >a {
           padding: 1em .5em;
           font-size: 1em;
@@ -1133,7 +1133,7 @@ body.neighborhoods-lp {
 
   }
 
-  @media (max-width: 550px) { 
+  @media (max-width: 550px) {
 
     ul#menu-zone-in {
       //border:1px solid black;
@@ -1188,7 +1188,7 @@ body.neighborhoods-lp {
     }
   }
 
-  @media (max-width: 480px) { 
+  @media (max-width: 480px) {
     .map {
       .plan-status {
         .zone-w-status {
@@ -1316,16 +1316,18 @@ body.neighborhoods-lp {
     }
 
     @media (max-width:550px){
-      section .news .span3, 
-      section .news .span3 img, 
+      section .news .span3,
+      section .news .span3 img,
       section .news .span9 {
         min-width: 100%;
         margin-bottom: .5em;
         margin-left:0;
       }
     }
-
   }
 
+.navbar li.home-icon > a img {
+	height: 45px;
 }
 
+}

--- a/wp-content/themes/citylimits/style.css
+++ b/wp-content/themes/citylimits/style.css
@@ -400,7 +400,7 @@ body .wpjb .wpjb-login-message ol li {
   }
 }
 /**
- * Rezone / ZoneIn Project 
+ * Rezone / ZoneIn Project
  */
 body.neighborhoods-lp {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -1562,4 +1562,7 @@ body.neighborhoods-lp.tax-neighborhoods .gform_widget h3 {
     margin-bottom: .5em;
     margin-left: 0;
   }
+}
+body.neighborhoods-lp .navbar li.home-icon > a img {
+  height: 45px;
 }

--- a/wp-content/themes/citylimits/style.css
+++ b/wp-content/themes/citylimits/style.css
@@ -1563,6 +1563,6 @@ body.neighborhoods-lp.tax-neighborhoods .gform_widget h3 {
     margin-left: 0;
   }
 }
-body.neighborhoods-lp .navbar li.home-icon > a img {
+.navbar li.home-icon > a img {
   height: 45px;
 }


### PR DESCRIPTION
The sticky header logo (mobile logo) was too small, so this ncreases the .navbar li.home-icon > a img to 45px.