### PR TITLE
make the terms into an array on the contentgroup

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -347,11 +347,13 @@ function citylimits_google_analytics() {
 				foreach ( $taxonomies as $tax_key => $taxonomy ) {
 
 					$terms = wp_get_post_terms( $post->ID, $taxonomy );
+					$contentGroups = array();
 					foreach ( $terms as $term ) {
 						if ( ! empty ( $term->name ) ){
-							echo "ga( 'set', 'contentGroup" . $tax_key . "', '" . esc_attr( $term->name ) . "' );\n";
+							$contentGroups[] = "'" . esc_attr( $term->name ) . "'";
 						}
 					}
+					echo "ga( 'set', 'contentGroup" . $tax_key . "', [ " . implode( ', ', $contentGroups ) . " ] );\n";
 				}
 			} elseif ( is_tax() ) {
 				$term = $wp_query->get_queried_object();


### PR DESCRIPTION
This is a might-work, but it's not guaranteed to. I'd like to try it on production.

```js

( function ( i, s, o, g, r, a, m ) {i['GoogleAnalyticsObject']=r;i[r]=i[r]|| function() {( i[r].q=i[r].q||[] ).push( arguments )},i[r].l=1*new Date();a=s.createElement( o ), m=s.getElementsByTagName( o )[0];a.async=1;a.src=g;m.parentNode.insertBefore( a, m )} )
( window,document,'script','https://www.google-analytics.com/analytics.js','ga' );

ga( 'create', 'UA-529003-1', 'auto' );

ga( 'set', 'contentGroup1', [ 'HOUSING and DEVELOPMENT', 'Queens' ] );
ga( 'set', 'contentGroup2', [ 'Downtown Far Rockaway' ] );
ga( 'set', 'contentGroup3', [ 'Homepage Featured', 'Homepage Top Story' ] );
ga( 'set', 'contentGroup4', [ 'News' ] );
ga( 'set', 'contentGroup5', [ 'ZoneIn' ] );

ga( 'send', 'pageview' );

```