### PR TITLE
Change mapping-the-future slug to futuremap

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -259,7 +259,9 @@ function citylimits_google_analytics() {
 			global $post, $wp_query;
 
 			if ( is_singular() ) {
-				if ( has_term( 'zonein', 'series' ) or has_term( 'mapping-the-future', 'series' ) ) {
+				// Single objects
+
+				if ( has_term( 'zonein', 'series' ) or has_term( 'futuremap', 'series' ) ) {
 					echo "ga( 'set', 'contentGroup1', 'MappingTheFuture' );\n";
 				} elseif ( 'page-neighborhoods.php' === get_page_template_slug() ) {
 					echo "ga( 'set', 'contentGroup1', 'MappingTheFuture' );\n";
@@ -289,8 +291,10 @@ function citylimits_google_analytics() {
 					echo "ga( 'set', 'contentGroup2', 'election2017' );\n";
 				}
 			} elseif ( is_tax() || is_archive() ) {
+				// Term archives
+
 				$term = $wp_query->get_queried_object();
-				if ( $term->name === 'ZoneIn' || $term->name === "Mapping the Future" || $term->taxonomy === 'neighborhoods' ) {
+				if ( $term->slug === 'zonein' || $term->slug === 'futuremap'|| $term->taxonomy === 'neighborhoods' ) {
 					echo "ga( 'set', 'contentGroup1', 'MappingTheFuture' );\n";
 				}
 				if (

--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -294,7 +294,12 @@ function citylimits_google_analytics() {
 				// Term archives
 
 				$term = $wp_query->get_queried_object();
-				if ( $term->slug === 'zonein' || $term->slug === 'futuremap'|| $term->taxonomy === 'neighborhoods' ) {
+				if (
+					$term->slug === 'zonein'
+					|| $term->slug === 'futuremap'
+					|| $term->slug === 'zonein-espanol'
+					|| $term->taxonomy === 'neighborhoods'
+				) {
 					echo "ga( 'set', 'contentGroup1', 'MappingTheFuture' );\n";
 				}
 				if (


### PR DESCRIPTION
## Changes

- Change `mapping-the-future` slug to `futuremap`, for #34 
- term name matches to term slug matches, so that term name changes don't catch us out

Fixes https://github.com/INN/umbrella-citylimits/issues/34