### PR TITLE
Use `include( locate_template(` instead of `get_template_part`

### DIFF
--- a/wp-content/themes/citylimits/page-neighborhoods.php
+++ b/wp-content/themes/citylimits/page-neighborhoods.php
@@ -30,9 +30,9 @@ get_header( 'rezone' );
 
 <?php
 	get_template_part( 'partials/neighborhoods', 'overview' );
-	get_template_part( 'partials/neighborhoods', 'news' );
-	get_template_part( 'partials/neighborhoods', 'videos' );
-	get_template_part( 'partials/neighborhoods', 'commentary' );
+	include( locate_template( 'partials/neighborhoods-news.php' ) );
+	include( locate_template( 'partials/neighborhoods-videos.php' ) );
+	include( locate_template( 'partials/neighborhoods-commentary.php' ) );
 	get_template_part( 'partials/neighborhoods', 'map' );
 	get_template_part( 'partials/neighborhoods', '101' );
 	get_template_part( 'partials/neighborhoods', 'documents' );

--- a/wp-content/themes/citylimits/page-neighborhoods.php
+++ b/wp-content/themes/citylimits/page-neighborhoods.php
@@ -29,12 +29,12 @@ get_header( 'rezone' );
 
 
 <?php
-	get_template_part( 'partials/neighborhoods', 'overview' );
+	include( locate_template( 'partials/neighborhoods-overview.php' ) );
 	include( locate_template( 'partials/neighborhoods-news.php' ) );
 	include( locate_template( 'partials/neighborhoods-videos.php' ) );
 	include( locate_template( 'partials/neighborhoods-commentary.php' ) );
-	get_template_part( 'partials/neighborhoods', 'map' );
-	get_template_part( 'partials/neighborhoods', '101' );
-	get_template_part( 'partials/neighborhoods', 'documents' );
-	get_template_part( 'partials/neighborhoods', 'ctas' );
+	include( locate_template( 'partials/neighborhoods-map.php' ) );
+	include( locate_template( 'partials/neighborhoods-101.php' ) );
+	include( locate_template( 'partials/neighborhoods-documents.php' ) );
+	include( locate_template( 'partials/neighborhoods-ctas.php' ) );
 	get_footer();


### PR DESCRIPTION
This way we can pass the `$project_tax_query` argument to use in the `neighborhoods` partials that require it for their queries, like this:

https://github.com/INN/umbrella-citylimits/blob/97ebb54ea5d76882d0a5ca64e36c68def1dd2eaa/wp-content/themes/citylimits/partials/neighborhoods-news.php#L5-L17

## Changes

This pull request makes the following changes:

- Swapped `get_template_part` with `include( locate_template(` for `partials/neighborhoods-news'`, `partials/neighborhoods-videos` and `partials/neighborhoods-commentary`.


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #36, the `$project_tax_query` variable wasn't being passed to the `partials/neighborhoods-news'`, `partials/neighborhoods-videos` and `partials/neighborhoods-commentary` partials, so their queries were not searching for the correct items.

## Testing/Questions

Features that this PR affects:

- Mapping the Future landing page

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Should we swap all partials in this file to use `include( locate_template(` instead of `get_template_part()`, or just the ones that require the `$project_tax_query` variable?

Steps to test this PR:

1. View the Mapping the Future landing page
2. Confirm no stories/videos/opinion articles are displaying that are not supposed to be.

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [ ] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [ ] Contributor agrees to the license terms of this repository.
