### PR TITLE
Use `largo-modernizr` as dependency for `citylimits-navigation`

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -390,7 +390,7 @@ add_action( 'init', 'register_citylimits_menu_locations' );
  */
 function citylimits_enqueue_styles(){
 	wp_enqueue_style( 'dashicons' );
-	wp_enqueue_script( 'citylimits-navigation', get_stylesheet_directory_uri() . '/js/navigation.js', array( 'jquery' ), '1.0', true );
+	wp_enqueue_script( 'citylimits-navigation', get_stylesheet_directory_uri() . '/js/navigation.js', array( 'jquery', 'largo-modernizr' ), '1.0', true );
 }
 add_action( 'wp_enqueue_scripts', 'citylimits_enqueue_styles' );
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates the `citylimits-navigation` enqueue to use `largo-modernizr` as a dependency to (hopefully) solve the `Modernizr.hasEvent is not a function` error on staging

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #39

## Testing/Questions

Features that this PR affects:

- Site header

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Make sure everything still works and no new errors are present