### PR TITLE
Bandaid fix for play icon appearing on special projects widget :(

### DIFF
--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-seven-stories-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-seven-stories-widget.php
@@ -125,6 +125,7 @@ class Citylimits_Series_Seven_Stories_Widget extends WP_Widget {
 					'instance' => $instance,
 					'thumb' => '',
 					'excerpt' => $excerpt,
+					'podcast' => false,
 				);
 
 				if ( $counter === 1 ) {

--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-featured-content-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-featured-content-widget.php
@@ -119,7 +119,8 @@ class citylimits_special_projects_featured_content_widget extends WP_Widget {
 					$context = array(
 						'instance' => $instance,
 						'thumb' => $thumb,
-						'excerpt' => $excerpt
+						'excerpt' => $excerpt,
+						'podcast' => false,
 					);
 
 					ob_start();

--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-widget.php
@@ -86,6 +86,7 @@ class citylimits_special_projects_widget extends WP_Widget {
 						'instance' => $instance,
 						'thumb' => false,
 						'excerpt' => $excerpt,
+						'podcast' => false,
 					);
 
 					$series->the_post();


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds `'podcast' => false,` to `$context` in the City Limits special projects homepage widget

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #87

## Testing/Questions

Features that this PR affects:

- City Limits homepage special projects widget

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Is this ok enough for an ugly bandaid fix?

Steps to test this PR:

1. Add podcasts widget above the City Limits homepage special projects widget
2. Verify play icon does not appear for posts in this widget