### PR TITLE
Cachebust :allthethings:

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -306,16 +306,6 @@ function zonein_tax_archive_query( $query ) {
 }
 add_action( 'pre_get_posts', 'zonein_tax_archive_query', 1 );
 
-/**
- * get other scripts
- */
-function citylimits_communitywire_enqueue() {
- 	if (is_page_template( 'page-communitywire.php' )) {
-		wp_enqueue_script( 'inn-tools', get_stylesheet_directory_uri() . '/js/communitywire.js', array( 'jquery' ), '1.1', true );
-	}
-}
-add_action( 'wp_enqueue_scripts', 'citylimits_communitywire_enqueue' );
-
 /* need this to allow Gravity Forms to post to API */
 add_filter( 'gform_webhooks_request_args', function ( $request_args, $feed ) {
     $request_url = rgars( $feed, 'meta/requestURL' );
@@ -334,32 +324,6 @@ function set_max_srcset_image_width( $max_width ) {
     return $max_width;
 }
 add_filter( 'max_srcset_image_width', 'set_max_srcset_image_width' );
-
-/**
- * newsletter subscribe forms
- */
-function citylimits_newsletter_enqueue() {
-	wp_register_script(
-		'jscookies',
-		get_stylesheet_directory_uri() . '/js/cookies.js',
-		null,
-		filemtime( get_stylesheet_directory() . '/js/cookies.js' ),
-		true
-	);
-	wp_register_script(
-		'cl-newsletter',
-		get_stylesheet_directory_uri() . '/js/newsletter.js',
-		array( 'jquery', 'jscookies' ),
-		filemtime( get_stylesheet_directory() . '/js/newsletter.js' ),
-		true
-	);
-	wp_localize_script(
-		'cl-newsletter',
-		'myAjax',
-		array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) )
-	);
-}
-add_action( 'wp_enqueue_scripts', 'citylimits_newsletter_enqueue' );
 
 function citylimits_newsletter_form_interstitial() {
 	get_template_part( 'partials/newsletter-signup', 'maincolumn' );
@@ -396,29 +360,6 @@ function register_citylimits_menu_locations() {
 
 }
 add_action( 'init', 'register_citylimits_menu_locations' );
-
-/**
- * Enqueue specific styles and scripts for City Limits child theme
- */
-function citylimits_enqueue_styles(){
-	wp_enqueue_style( 'dashicons' );
-	wp_enqueue_script(
-		'citylimits-navigation',
-		get_stylesheet_directory_uri() . '/js/navigation.js',
-		array( 'jquery', 'largo-modernizr' ),
-		'1.0',
-		true
-	);
-}
-add_action( 'wp_enqueue_scripts', 'citylimits_enqueue_styles' );
-
-/**
- * Dequeue specific scripts
- */
-function citylimits_dequeue_scripts(){
-	wp_dequeue_script( 'largo-navigation' );
-}
-add_action( 'wp_print_scripts', 'citylimits_dequeue_scripts', 100 );
 
 /**
  * Function to add thumbnail images to the secondary special project nav menu

--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -339,9 +339,25 @@ add_filter( 'max_srcset_image_width', 'set_max_srcset_image_width' );
  * newsletter subscribe forms
  */
 function citylimits_newsletter_enqueue() {
-	wp_register_script( 'jscookies', get_stylesheet_directory_uri() . '/js/cookies.js', null, '1.1', true );
-	wp_register_script( 'cl-newsletter', get_stylesheet_directory_uri() . '/js/newsletter.js', array( 'jquery', 'jscookies' ), null, true );
-	wp_localize_script( 'cl-newsletter', 'myAjax', array( 'ajaxurl' => admin_url( 'admin-ajax.php' )));
+	wp_register_script(
+		'jscookies',
+		get_stylesheet_directory_uri() . '/js/cookies.js',
+		null,
+		filemtime( get_stylesheet_directory() . '/js/cookies.js' ),
+		true
+	);
+	wp_register_script(
+		'cl-newsletter',
+		get_stylesheet_directory_uri() . '/js/newsletter.js',
+		array( 'jquery', 'jscookies' ),
+		filemtime( get_stylesheet_directory() . '/js/newsletter.js' ),
+		true
+	);
+	wp_localize_script(
+		'cl-newsletter',
+		'myAjax',
+		array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) )
+	);
 }
 add_action( 'wp_enqueue_scripts', 'citylimits_newsletter_enqueue' );
 
@@ -386,7 +402,13 @@ add_action( 'init', 'register_citylimits_menu_locations' );
  */
 function citylimits_enqueue_styles(){
 	wp_enqueue_style( 'dashicons' );
-	wp_enqueue_script( 'citylimits-navigation', get_stylesheet_directory_uri() . '/js/navigation.js', array( 'jquery', 'largo-modernizr' ), '1.0', true );
+	wp_enqueue_script(
+		'citylimits-navigation',
+		get_stylesheet_directory_uri() . '/js/navigation.js',
+		array( 'jquery', 'largo-modernizr' ),
+		'1.0',
+		true
+	);
 }
 add_action( 'wp_enqueue_scripts', 'citylimits_enqueue_styles' );
 

--- a/wp-content/themes/citylimits/inc/enqueue.php
+++ b/wp-content/themes/citylimits/inc/enqueue.php
@@ -118,6 +118,68 @@ remove_action( 'wp_enqueue_scripts', 'largo_enqueue_child_theme_css' );
 	}
 
 /**
+ * Enqueue specific styles and scripts for City Limits child theme
+ */
+function citylimits_enqueue_styles(){
+	wp_enqueue_style( 'dashicons' );
+	wp_enqueue_script(
+		'citylimits-navigation',
+		get_stylesheet_directory_uri() . '/js/navigation.js',
+		array( 'jquery', 'largo-modernizr' ),
+		filemtime( get_stylesheet_directory() . '/js/navigation.js' ),
+		true
+	);
+}
+add_action( 'wp_enqueue_scripts', 'citylimits_enqueue_styles' );
+
+/**
+ * Dequeue specific scripts
+ */
+function citylimits_dequeue_scripts(){
+	wp_dequeue_script( 'largo-navigation' );
+}
+add_action( 'wp_print_scripts', 'citylimits_dequeue_scripts', 100 );
+
+function citylimits_communitywire_enqueue() {
+ 	if (is_page_template( 'page-communitywire.php' )) {
+		wp_enqueue_script(
+			'inn-tools',
+			get_stylesheet_directory_uri() . '/js/communitywire.js',
+			array( 'jquery' ),
+			filemtime( get_stylesheet_directory() . '/js/communitywire.js' ),
+			true
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'citylimits_communitywire_enqueue' );
+
+/**
+ * newsletter subscribe forms
+ */
+function citylimits_newsletter_enqueue() {
+	wp_register_script(
+		'jscookies',
+		get_stylesheet_directory_uri() . '/js/cookies.js',
+		null,
+		filemtime( get_stylesheet_directory() . '/js/cookies.js' ),
+		true
+	);
+	wp_register_script(
+		'cl-newsletter',
+		get_stylesheet_directory_uri() . '/js/newsletter.js',
+		array( 'jquery', 'jscookies' ),
+		filemtime( get_stylesheet_directory() . '/js/newsletter.js' ),
+		true
+	);
+	wp_localize_script(
+		'cl-newsletter',
+		'myAjax',
+		array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'citylimits_newsletter_enqueue' );
+
+/**
  * ADD Google Tag Manager Verification code TO HEADER
  */
 add_action('wp_head', 'add_gtm');

--- a/wp-content/themes/citylimits/inc/enqueue.php
+++ b/wp-content/themes/citylimits/inc/enqueue.php
@@ -45,25 +45,6 @@ remove_action( 'wp_enqueue_scripts', 'largo_enqueue_child_theme_css' );
 			$version
 		);
 
-		wp_enqueue_style(
-			'largo-stylesheet',
-			get_template_directory_uri() . '/css/style' . $suffix . '.css',
-			null,
-			$version
-		);
-
-		wp_enqueue_style(
-			'typekit',
-			'https://use.typekit.net/xkz6lbv.css'
-		);
-
-		wp_enqueue_style(
-			'largo-child-styles',
-			get_stylesheet_directory_uri() . '/css/child-style.css',
-			array( 'largo-stylesheet', 'typekit' ),
-			filemtime( get_stylesheet_directory() . '/css/child-style.css' )
-		);
-
 		// Core JS includes some utilities, initializes carousels, search form behavior,
 		// popovers, responsive header image, etc.
 		wp_enqueue_script(
@@ -121,6 +102,18 @@ remove_action( 'wp_enqueue_scripts', 'largo_enqueue_child_theme_css' );
  * Enqueue specific styles and scripts for City Limits child theme
  */
 function citylimits_enqueue_styles(){
+	wp_enqueue_style(
+		'typekit',
+		'https://use.typekit.net/xkz6lbv.css'
+	);
+
+	wp_enqueue_style(
+		'largo-child-styles',
+		get_stylesheet_directory_uri() . '/css/child-style.css',
+		array( 'largo-stylesheet', 'typekit' ),
+		filemtime( get_stylesheet_directory() . '/css/child-style.css' )
+	);
+
 	wp_enqueue_style( 'dashicons' );
 	wp_enqueue_script(
 		'citylimits-navigation',

--- a/wp-content/themes/citylimits/inc/job-board.php
+++ b/wp-content/themes/citylimits/inc/job-board.php
@@ -9,7 +9,13 @@
  * Enqueue custom sidebar styles
  */
 function largo_jobboard_enqueue() {
-	wp_enqueue_style('job-board-styles', get_stylesheet_directory_uri() . '/css/job-board.css', false, '20170609', 'screen');
+	wp_enqueue_style(
+		'job-board-styles',
+		get_stylesheet_directory_uri() . '/css/job-board.css',
+		false,
+		filemtime( get_stylesheet_directory() . '/css/job-board.css' ),
+		'screen'
+	);
 }
 add_action('wp_enqueue_scripts', 'largo_jobboard_enqueue' );
 

--- a/wp-content/themes/citylimits/inc/metaboxes.php
+++ b/wp-content/themes/citylimits/inc/metaboxes.php
@@ -127,27 +127,47 @@ class CityLimits_Create_Meta_Boxes {
 	public function enqueue_datepicker() {
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 		wp_enqueue_script( 'jquery-ui-slider' );
-		wp_enqueue_script( 'jquery-timepicker', get_stylesheet_directory_uri().'/js/jquery-ui-timepicker-addon.js', array( 'jquery', 'jquery-ui-datepicker', 'jquery-ui-slider' ) );
+		wp_enqueue_script(
+			'jquery-timepicker',
+			get_stylesheet_directory_uri().'/js/jquery-ui-timepicker-addon.js',
+			array( 'jquery', 'jquery-ui-datepicker', 'jquery-ui-slider' ),
+			filemtime( get_stylesheet_directory().'/js/jquery-ui-timepicker-addon.js' )
+		);
 	}
 
 	public function initialize_datepicker() {
 		$current_screen = get_current_screen();
 		if ( in_array( $current_screen->id, $this->screens ) ) { 
-			wp_register_style( 'jquery-ui-smoothness', get_stylesheet_directory_uri().'/css/jquery-ui-smoothness' . $suffix . '.css' );
-			wp_register_style( 'jquery-ui-datepicker', get_stylesheet_directory_uri().'/css/datepicker' . $suffix . '.css' );
-			wp_register_style( 'jquery-ui-timepicker-addon', get_stylesheet_directory_uri().'/css/jquery-ui-timepicker-addon' . $suffix . '.css' );
+			wp_register_style(
+				'jquery-ui-smoothness',
+				get_stylesheet_directory_uri().'/css/jquery-ui-smoothness.css',
+				array(),
+				filemtime( get_stylesheet_directory().'/css/jquery-ui-smoothness.css' ),
+			);
+			wp_register_style(
+				'jquery-ui-datepicker',
+				get_stylesheet_directory_uri().'/css/datepicker.css',
+				array(),
+				filemtime( get_stylesheet_directory().'/css/datepicker.css' ),
+			);
+			wp_register_style(
+				'jquery-ui-timepicker-addon',
+				get_stylesheet_directory_uri().'/css/jquery-ui-timepicker-addon.css',
+				array(),
+				filemtime( get_stylesheet_directory().'/css/jquery-ui-timepickr-addon.css' ),
+			);
 
 			wp_enqueue_style( 'jquery-ui-smoothness' );
 			wp_enqueue_style( 'jquery-ui-datepicker' );
 			wp_enqueue_style( 'jquery-ui-timepicker-addon' );
 			?>
-			<script>
-				jQuery(document).ready(function($) {
-					$("input[type=datetime]").datetimepicker();
-				});
-			</script>
-		<?php
+				<script>
+					jQuery(document).ready(function($) {
+						$("input[type=datetime]").datetimepicker();
+					});
+				</script>
+			<?php
 		}
-	}	
+	}
 }
 new CityLimits_Create_Meta_Boxes;

--- a/wp-content/themes/citylimits/inc/metaboxes.php
+++ b/wp-content/themes/citylimits/inc/metaboxes.php
@@ -154,7 +154,7 @@ class CityLimits_Create_Meta_Boxes {
 				'jquery-ui-timepicker-addon',
 				get_stylesheet_directory_uri().'/css/jquery-ui-timepicker-addon.css',
 				array(),
-				filemtime( get_stylesheet_directory().'/css/jquery-ui-timepickr-addon.css' ),
+				filemtime( get_stylesheet_directory().'/css/jquery-ui-timepicker-addon.css' ),
 			);
 
 			wp_enqueue_style( 'jquery-ui-smoothness' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- moves a bunch of enqueues and registers into `inc/enqueue.php`
- applies filemtime cachebusters to them all
- moves Citylimits-specific enqueues out of the modified `largo_enqueue_js()`, so that it's easier to compare that modified function to Largo's in the future. I think the existing citylimits js/navigation.js still depends on the modified variables, though, so I'm not removing the duplicated function at this time. (although it looks like js/navigation.js is checking for a property `sticky_nav_display` that is not set by the function, which uses `sticky_nav_display_article`? )

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Resolves #121

So that, when we deploy, useragents won't be stuck using cached assets.

## Testing/Questions

Features that this PR affects:

- potentially navigation.js
- not the Job Board, because the Job Board PHP files aren't actually included in the active theme

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] is anything broken?

Steps to test this PR:

1. poke around!