### PR TITLE
Remove duplicate hero image on posts, update largo_byline on older templates

### DIFF
--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-podcast-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-podcast-widget.php
@@ -116,7 +116,7 @@ class Citylimits_Podcasts_Widget extends WP_Widget {
 				// wrap the items in li's.
 				$output .= sprintf(
 					'<li class="%1$s" >',
-					implode( ' ', get_post_class( '', get_the_id() ) )
+					implode( ' ', get_post_class( '', get_the_ID() ) )
 				);
 
 				$context = array(

--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-posts-continued.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-posts-continued.php
@@ -116,7 +116,7 @@ class Citylimits_Series_Posts_Widget extends WP_Widget {
 				// wrap the items in li's.
 				$output .= sprintf(
 					'<li class="%1$s" >',
-					implode( ' ', get_post_class( '', get_the_id() ) )
+					implode( ' ', get_post_class( '', get_the_ID() ) )
 				);
 
 				$context = array(

--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-seven-stories-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-series-seven-stories-widget.php
@@ -118,7 +118,7 @@ class Citylimits_Series_Seven_Stories_Widget extends WP_Widget {
 				// wrap the items in li's.
 				$output .= sprintf(
 					'<li class="%1$s" >',
-					implode( ' ', get_post_class( '', get_the_id() ) )
+					implode( ' ', get_post_class( '', get_the_ID() ) )
 				);
 
 				$context = array(

--- a/wp-content/themes/citylimits/partials/content-single-classic.php
+++ b/wp-content/themes/citylimits/partials/content-single-classic.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * The template for displaying content in the single.php template
+ * The template for displaying content in the single-two-column.php template
  *
  * Copied from Largo in order to comment out the hero image
  *
- * @since Largo 0.5.5.2
- * @since February 21, 2017
+ * This doesn't actually affect the site, because single-two-column.php
+ * has its own template logic since https://github.com/INN/umbrella-citylimits/pull/99
+ *
+ * @since Largo 0.6.4
+ * @since November 14, 2019 - date of last comparison to Largo trunk
  */
 ?>
 
@@ -19,7 +22,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) )
 			echo '<h2 class="subtitle">' . $subtitle . '</h2>';
 		?>
-		<h5 class="byline"><?php largo_byline(); ?></h5>
+		<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 
 		<?php
 			if ( !of_get_option( 'single_social_icons' ) == false ) {
@@ -34,6 +37,7 @@
 	<?php
 		do_action( 'largo_after_post_header' );
 
+		// https://github.com/INN/umbrella-citylimits/pull/5
 		// largo_hero( null,'' );
 
 		do_action( 'largo_after_hero' );

--- a/wp-content/themes/citylimits/partials/content-single.php
+++ b/wp-content/themes/citylimits/partials/content-single.php
@@ -4,8 +4,8 @@
  *
  * Copied from Largo in order to comment out the hero image
  *
- * @since Largo 0.5.5.2
- * @since February 21, 2017
+ * @since Largo 0.6.4
+ * @since November 14, 2019 - date of last comparison to Largo trunk
  */
 ?>
 
@@ -21,7 +21,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
 			<h2 class="subtitle"><?php echo $subtitle ?></h2>
 		<?php endif; ?>
-		<h5 class="byline"><?php largo_byline(); ?></h5>
+		<h5 class="byline"><?php largo_byline( true, false, get_the_ID ); ?></h5>
 
 		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
 			largo_post_social_links();
@@ -34,7 +34,8 @@
 	<?php
 		do_action('largo_after_post_header');
 
-		//largo_hero(null,'span12');
+		// https://github.com/INN/umbrella-citylimits/pull/5
+		// largo_hero(null,'span12');
 
 		do_action('largo_after_hero');
 	?>
@@ -42,9 +43,9 @@
 	<?php get_sidebar(); ?>
 
 	<section class="entry-content clearfix" itemprop="articleBody">
-		
+
 		<?php largo_entry_content( $post ); ?>
-		
+
 	</section>
 
 	<?php do_action('largo_after_post_content'); ?>

--- a/wp-content/themes/citylimits/partials/neighborhoods-commentary.php
+++ b/wp-content/themes/citylimits/partials/neighborhoods-commentary.php
@@ -21,10 +21,10 @@
 			?>
 			<?php if ( $commentary->have_posts() ) : ?>
 				<?php $count = 0; ?>
-				<?php while ( $commentary->have_posts() ) : $commentary->the_post(); $shown_ids[] = get_the_id(); ?>
+				<?php while ( $commentary->have_posts() ) : $commentary->the_post(); $shown_ids[] = get_the_ID(); ?>
 					<div class="story">
 						<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-						<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+						<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 					</div>
 				<?php endwhile; ?>
 			<?php endif; ?>

--- a/wp-content/themes/citylimits/partials/neighborhoods-documents.php
+++ b/wp-content/themes/citylimits/partials/neighborhoods-documents.php
@@ -18,7 +18,7 @@
 		?>
 		<?php if ( $documents->have_posts() ) : ?>
 			<?php $count = 0; ?>
-			<?php while ( $documents->have_posts() ) : $documents->the_post(); $shown_ids[] = get_the_id(); ?>
+			<?php while ( $documents->have_posts() ) : $documents->the_post(); $shown_ids[] = get_the_ID(); ?>
 				<?php if ( 0 == $count%3 ) : ?>
 					<div class="span4">
 				<?php endif; ?>

--- a/wp-content/themes/citylimits/partials/neighborhoods-news.php
+++ b/wp-content/themes/citylimits/partials/neighborhoods-news.php
@@ -18,7 +18,7 @@
 		$recent_posts = new WP_Query( $args );
 		if ( $recent_posts->have_posts() ) :
 			$count = 0;
-			while ( $recent_posts->have_posts() ) : $recent_posts->the_post(); $shown_ids[] = get_the_id();
+			while ( $recent_posts->have_posts() ) : $recent_posts->the_post(); $shown_ids[] = get_the_ID();
 			?>
 				<?php if ( 0 == $count ) : ?>
 					<div class="news-feature span8">
@@ -27,7 +27,7 @@
 						</div>
 						<div class="span6">
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-							<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+							<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 							<?php the_excerpt(); ?>
 							<a href="<?php the_permalink(); ?>" class="read-more">Read more ></a>
 						</div>
@@ -36,18 +36,18 @@
 					<div class="span4">
 						<div <?php post_class( 'story' ); ?> >
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-							<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+							<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 						</div>
 				<?php elseif ( 3 == $count ) : ?>
 						<div <?php post_class( 'story' ); ?> >
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-							<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+							<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 						</div>
 					</div>
 				<?php else : ?>
 						<div <?php post_class( 'story' ); ?> >
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-							<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+							<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 						</div>
 				<?php endif; ?>
 			<?php $count++; ?>
@@ -56,4 +56,3 @@
 	</div>
 	<div class="morelink"><a href="<?php echo get_term_link( 'news', 'post-type' ); ?>" class="btn more">More News</a></div>
 </section>
-

--- a/wp-content/themes/citylimits/partials/neighborhoods-videos.php
+++ b/wp-content/themes/citylimits/partials/neighborhoods-videos.php
@@ -19,11 +19,11 @@
 		?>
 		<?php if ( $videos->have_posts() ) : ?>
 			<?php $count = 0; ?>
-			<?php while ( $videos->have_posts() ) : $videos->the_post(); $shown_ids[] = get_the_id(); ?>
+			<?php while ( $videos->have_posts() ) : $videos->the_post(); $shown_ids[] = get_the_ID(); ?>
 				<div class="span4">
 					<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'full' ); ?></a>
 					<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-					<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+					<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 				</div>
 				<?php $count++; ?>
 			<?php endwhile; ?>

--- a/wp-content/themes/citylimits/single-two-column.php
+++ b/wp-content/themes/citylimits/single-two-column.php
@@ -83,7 +83,9 @@ get_header();
 				if ( $partial == 'single-classic' ) {
 					do_action( 'largo_after_post_header' );
 
-					largo_hero( null,'' );
+					// https://github.com/INN/umbrella-citylimits/pull/5
+					// https://github.com/INN/umbrella-citylimits/issues/124
+					// largo_hero( null,'' );
 
 					do_action( 'largo_after_hero' );
 

--- a/wp-content/themes/citylimits/taxonomy-neighborhoods.php
+++ b/wp-content/themes/citylimits/taxonomy-neighborhoods.php
@@ -95,7 +95,7 @@ $queried_object = get_queried_object();
 						<h2>Photos</h2>
 						<div class="row-fluid">
 						</div>
-						<?php while ( $photos->have_posts() ) : $photos->the_post(); $shown_ids[] = get_the_id(); ?>
+						<?php while ( $photos->have_posts() ) : $photos->the_post(); $shown_ids[] = get_the_ID(); ?>
 							<!-- <div class="span4">
 								<a href=" <?php echo the_post_thumbnail_url( 'full' ); ?> " target="_blank"><?php the_post_thumbnail( 'medium' ); ?></a>
 							</div> -->

--- a/wp-content/themes/citylimits/taxonomy-neighborhoods.php
+++ b/wp-content/themes/citylimits/taxonomy-neighborhoods.php
@@ -128,14 +128,14 @@ $queried_object = get_queried_object();
 				<?php if ( $news->have_posts() ) : ?>
 					<section class="news">
 						<h2>News</h2>
-						<?php while ( $news->have_posts() ) : $news->the_post(); $shown_ids[] = get_the_id(); ?>
+						<?php while ( $news->have_posts() ) : $news->the_post(); $shown_ids[] = get_the_ID(); ?>
 							<div class="row-fluid">
 								<div class="span3">
 									<?php the_post_thumbnail( 'medium' ); ?>
 								</div>
 								<div class="span9">
 									<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-									<h5 class="byline"><?php largo_byline( true, true ); ?></h5>
+									<h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
 									<?php the_excerpt(); ?>
 									<a href="<?php the_permalink(); ?>" class="read-more">Read more ></a>
 								</div>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Comments out `largo_hero()` call in the `single-two-column.php` template added for #99
- Updates the existing `partials/content-single-classic.php` and `partials/content-single.php` added in https://github.com/INN/umbrella-citylimits/pull/5 for compatibility with Largo 0.6.4 by adding the post ID to `largo_byline()` calls, in accordance with https://github.com/INN/largo/issues/1517
- Adds the post ID to all other `largo_byline()` calls in this theme
- Correct capitalization on all `get_post_id()` calls to `get_post_ID()`, to match the function declaration https://developer.wordpress.org/reference/functions/get_the_ID/

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #124

## Testing/Questions

Features that this PR affects:

- Article content

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] does it work?

Steps to test this PR:

1. Check it out.