### PR TITLE
Remove trailing commas

### DIFF
--- a/wp-content/themes/citylimits/inc/metaboxes.php
+++ b/wp-content/themes/citylimits/inc/metaboxes.php
@@ -142,19 +142,19 @@ class CityLimits_Create_Meta_Boxes {
 				'jquery-ui-smoothness',
 				get_stylesheet_directory_uri().'/css/jquery-ui-smoothness.css',
 				array(),
-				filemtime( get_stylesheet_directory().'/css/jquery-ui-smoothness.css' ),
+				filemtime( get_stylesheet_directory().'/css/jquery-ui-smoothness.css' )
 			);
 			wp_register_style(
 				'jquery-ui-datepicker',
 				get_stylesheet_directory_uri().'/css/datepicker.css',
 				array(),
-				filemtime( get_stylesheet_directory().'/css/datepicker.css' ),
+				filemtime( get_stylesheet_directory().'/css/datepicker.css' )
 			);
 			wp_register_style(
 				'jquery-ui-timepicker-addon',
 				get_stylesheet_directory_uri().'/css/jquery-ui-timepicker-addon.css',
 				array(),
-				filemtime( get_stylesheet_directory().'/css/jquery-ui-timepicker-addon.css' ),
+				filemtime( get_stylesheet_directory().'/css/jquery-ui-timepicker-addon.css' )
 			);
 
 			wp_enqueue_style( 'jquery-ui-smoothness' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes trailing commas in `inc/metaboxes.php` that were introduced in #123 
(Tested on staging already and it's working fine now)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
It's breaking the FW staging environment 🤷‍♂ 

## Testing/Questions

Features that this PR affects:

- Things being enqueued in `inc/metaboxes.php`

Steps to test this PR:

1. Poke around and make sure nothing is broken