### PR TITLE
Make sure CAP author shows instead of user who created CAP author

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -572,3 +572,33 @@ function citylimits_special_projects_featured_content_widget_partial( $partial, 
 
 }
 add_filter( 'largo_lmp_template_partial', 'citylimits_special_projects_featured_content_widget_partial', 10, 2);
+
+/**
+ * Update author archive page titles so the correct CAP author shows if relevant
+ * 
+ * @param String $title The title being output
+ * @return String $title The title being output
+ */
+function citylimits_yoast_filter_author_page_title( $title ) {
+
+	if( ! is_author() ) {
+		return $title;
+	}
+
+	// current name that's displaying
+	$current_display_name = get_the_author_meta( 'display_name', get_query_var( 'author' ) );
+
+	// object for the real author
+	$author_obj = get_queried_object();
+
+	// new display name to swap in for the real author
+	$new_display_name = $author_obj->display_name;
+
+	if( $current_display_name != $new_display_name ){
+		return str_replace( $current_display_name, $new_display_name, $title );
+	} else {
+		return $title;
+	}
+
+}
+add_filter( 'wpseo_title', 'citylimits_yoast_filter_author_page_title' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a function to use the `wpseo_title` filter to use the correct author name for the output page title

Before:
![Screen Shot 2020-01-03 at 12 47 16 PM](https://user-images.githubusercontent.com/18353636/71739403-53a2c580-2e27-11ea-98ff-ca777d3acc30.png)

After:
![Screen Shot 2020-01-03 at 12 47 48 PM](https://user-images.githubusercontent.com/18353636/71739402-53a2c580-2e27-11ea-9c85-2e0757f032b6.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #134

## Testing/Questions

Features that this PR affects:

- Author archive page title

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View a CAP author archive, such as `/author/alessia-milstein/` and verify the tab title displays the correct author name