### PR TITLE
Remove the Mapping the Future project logo from header-rezone.php

### DIFF
--- a/wp-content/themes/citylimits/header-rezone.php
+++ b/wp-content/themes/citylimits/header-rezone.php
@@ -155,7 +155,6 @@ add_filter('body_class', function($classes) {
 			<div class="row-fluid">
 				<div class="span12">
 					<?php get_template_part( 'partials/nav', 'main' ); ?>
-					<a href="/series/zonein/"><img src="<?php echo get_stylesheet_directory_uri(); ?>/img/mapping-the-future-logo.png" alt="Mapping The Future Project Logo" width="100%" /></a>
 					<?php get_template_part( 'partials/nav', 'rezone' ); ?>
 				</div>
 			</div>


### PR DESCRIPTION
## Changes

This pull request removes the "Mapping the Future" logo from the header that is used on:

- `page-neighborhoods.php` - https://citylimits.org/zonein/
- `page-communitywire.php` - I'm unsure where this is used; my db copy says post 2988252 which is https://citylimits.org/communitywire-home/ but that's a 404 on prod
- `page-neighborhood-info.php` - https://citylimits.org/zonein/affordable-housing-101/ as an example


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #147 because this logo is old

## Testing/Questions

Features that this PR affects:

- the above-mentioned pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Do we want to try to merge `header.php` and `header-rezone.php` somehow, like for example having `header-rezone.php` load `header.php`? They're not that different, with the exception of:
    - the addition of a body class for rezone
    - the `.rezone-header` section containing the menu
    - js for the rezone menu
    - removal of the global nav, which we aren't using anyways
    - the addition in `header.php` of improved support for things like WordPress' title tag and `wp_body_open`

Steps to test this PR:

1. Visit the localhost equivalents of any of those above-mentioned URLs. Alternately, search your `wp_post_meta` table for `meta_value` matching any of the post templates mentioned above, and view those posts.