### PR TITLE
149 add filtering to special projects widget

### DIFF
--- a/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-featured-content-widget.php
+++ b/wp-content/themes/citylimits/inc/widgets/class-citylimits-special-projects-featured-content-widget.php
@@ -88,15 +88,6 @@ class citylimits_special_projects_featured_content_widget extends WP_Widget {
 			if ( ! empty( $instance['author'] ) ) {
 				$query_args['author'] = $instance['author'];
 			}
-			if ( ! empty( $instance['taxonomy'] ) && ! empty( $instance['term'] ) ) {
-				$query_args['tax_query'] = array(
-					array(
-						'taxonomy'	=> $instance['taxonomy'],
-						'field' 	=> 'slug',
-						'terms' 	=> $instance['term']
-					)
-				);
-			}
 
 			//stores original 'paged' value in 'pageholder'
 			global $cftl_previous;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds ability to filter based on (below) for the series special projects widget, based on the Largo Recent Posts filters
   - author
   - category
   - tag

- Moves the `$posts_term` var to earlier in the file since it was previously being declared after it was used, causing an output of `No recent .` as opposed to `No recent articles.`

![Screen Shot 2020-02-05 at 4 19 40 PM](https://user-images.githubusercontent.com/18353636/73884319-9e9f6680-4833-11ea-8753-d8223da5bb5c.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #149

## Testing/Questions

Features that this PR affects:

- Special projects featured content widget

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Do we need to add any other filters here, @MirandaEcho?

Steps to test this PR:

1. Add the City Limits Special Projects Featured Content widget to a series widget area and try out all of the new filters and make sure they work as expected.