### PR TITLE
Allow neighborhoods taxonomy to be shown in rest api

### DIFF
--- a/wp-content/themes/citylimits/functions.php
+++ b/wp-content/themes/citylimits/functions.php
@@ -147,6 +147,7 @@ function create_neighborhoods_taxonomy() {
 		'show_admin_column'          => true,
 		'show_in_nav_menus'          => true,
 		'show_tagcloud'              => true,
+		'show_in_rest'               => true,
 	);
 	register_taxonomy( 'neighborhoods', array( 'post' ), $args );
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds `show_in_rest => true` to the Neighborhoods taxonomy `$args` so that the taxonomy can be used in Gutenberg

From https://codex.wordpress.org/Function_Reference/register_taxonomy
```
show_in_rest
(boolean) (optional) Whether to include the taxonomy in the REST API. You will need to set this to true in order to use the taxonomy in your gutenberg metablock.
Default: false
```

![Screen Shot 2020-02-11 at 10 55 48 AM](https://user-images.githubusercontent.com/18353636/74253459-1c90c100-4cbd-11ea-8073-28716ee9c7cc.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #155 

## Testing/Questions

Features that this PR affects:

- Neighborhoods taxonomy

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Edit a post with the Gutenberg editor and make sure the Neighborhoods metabox shows up on the document sidebar