### PR TITLE
Remove zone status from neighborhoods template

### DIFF
--- a/wp-content/themes/citylimits/taxonomy-neighborhoods.php
+++ b/wp-content/themes/citylimits/taxonomy-neighborhoods.php
@@ -58,8 +58,6 @@ $queried_object = get_queried_object();
 
 					<?php largo_post_social_links(); ?>
 
-					<div class="zone-w-status"><div class="circle <?php echo $status; ?>"></div><?php echo ucfirst( $status ); ?></div>
-
 					<?php if ( isset( $description ) ) : ?>
 						<div class="archive-description"><?php echo $description; ?></div>
 					<?php endif; ?>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the zone status from the neighborhoods tax template

Before:
![Screen Shot 2020-02-21 at 10 54 44 AM](https://user-images.githubusercontent.com/18353636/75049761-b6fcbb80-5498-11ea-93f3-7a8bf1face45.png)

After:
![Screen Shot 2020-02-21 at 10 55 40 AM](https://user-images.githubusercontent.com/18353636/75049758-b6642500-5498-11ea-9e45-97ac049760b3.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #160

## Testing/Questions

Features that this PR affects:

- Neighborhoods taxonomy template

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Anything else need removed?

Steps to test this PR:

1. View a neighborhood such as https://citylimits.test/neighborhoods/east-harlem/ and make sure its zoning status doesn't appear above the description